### PR TITLE
UPDATE: 関連タグを取得し、グラフとして描画できるようにした

### DIFF
--- a/components/HobbyNode.vue
+++ b/components/HobbyNode.vue
@@ -1,27 +1,27 @@
 <template>
   <div class="node_div">
-    <nuxt-link :to="'/' + node.id + '/graph/'"
-      >関連の趣味 {{ node.title }}
+    <nuxt-link :to="'/' + tag.id + '/graph/'"
+      >関連の趣味 {{ tag.name }}
     </nuxt-link>
   </div>
 </template>
 <script>
 export default {
-  props: ["node"],
+  props: ["tag"],
 };
 </script>
 
 <style>
-  .node_div{
-    width: 33vw;
-    height: 33vw;
-    border-radius: 50%;
-    /* border: solid 5px rgb(63, 210, 71, .3); */
-    border: solid 5px #00a896b3;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    /* background-color: rgb(63, 192, 71, .3); */
-    background-color: #02c39a4d;
-  }
+.node_div {
+  width: 33vw;
+  height: 33vw;
+  border-radius: 50%;
+  /* border: solid 5px rgb(63, 210, 71, .3); */
+  border: solid 5px #00a896b3;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  /* background-color: rgb(63, 192, 71, .3); */
+  background-color: #02c39a4d;
+}
 </style>

--- a/pages/_hobbyId/graph.vue
+++ b/pages/_hobbyId/graph.vue
@@ -8,8 +8,8 @@
           >記事を読む</nuxt-link
         >
       </div>
-      <div v-for="rNode in relativeNodes" :key="rNode.id">
-        <HobbyNode :node="rNode" />
+      <div v-for="tag in relativeTags" :key="tag.id">
+        <HobbyNode :tag="tag" />
       </div>
     </div>
     <div v-else>
@@ -29,7 +29,7 @@ export default {
       name: "グラフ",
       id: this.$route.params.hobbyId,
       targetNode: {},
-      relativeNodes: [],
+      relativeTags: {},
     };
   },
   created() {
@@ -39,15 +39,15 @@ export default {
       });
       this.targetNode = this.targetNode[0]; //これで解決
       this.name = this.targetNode.name;
-      console.log("this.targetNode.id" + this.targetNode.id);
-      this.relativeNodes = this.$getRelativeTags(this.targetNode.id).then(
-        (tag) => {
-          console.debug(`tag relevance(graph.vue) : ${tag}`);
-          this.relativeNodes.push(tag.id);
-        }
-      );
-      console.debug(`target(graph.vue) : ${JSON.stringify(this.targetNode)}`);
-      console.debug(`relativeNodes(graph.vue) : ${this.relativeNodes}`);
+      console.debug(`this.name (created() in graph.vue): ${this.name}`);
+      console.debug(`this.targetNode.id (created() in graph.vue): ${this.targetNode.id}`);
+      console.debug(`this.target (created() in graph.vue) : ${JSON.stringify(this.targetNode)}`);
+    });
+    this.$getRelativeTags(this.id).then((tags) => {
+      this.relativeTags = tags;
+      console.debug(`tags (created() in graph.vue): ${tags}`);
+      console.debug(`Object.keys(tags) (created() in graph.vue): ${Object.keys(tags)}`);
+      console.debug(`this.relativeTags (created() in graph.vue) : ${this.relativeTags}`);
     });
   },
 };

--- a/plugins/firebaseUtils.js
+++ b/plugins/firebaseUtils.js
@@ -20,11 +20,12 @@ Vue.prototype.$getTags = async function getTags() {
     .catch((e) => {
       console.error(e);
     });
-  console.debug("tags(getTags) : ", tags)
+  console.debug(`tags (getTags() in firebaseUtils.js) : ${tags}`);
   return tags
 },
 
   Vue.prototype.$getRelativeTags = async function getRelativeTags(tagId) {
+    console.debug(`tagId (getRalativeTags() in firebaseUtils.js): ${tagId}`);
     let relativeTags = [];
     await db
       .collection("tags")
@@ -39,7 +40,7 @@ Vue.prototype.$getTags = async function getTags() {
       .catch((e) => {
         console.error(e);
       });
-    console.debug("tags(getRativeTags) : ", relativeTags)
+    console.debug(`tags (getRativeTags() in firebaseUtils.js) : ${relativeTags}`);
     return relativeTags
   },
 
@@ -52,9 +53,6 @@ Vue.prototype.$getTags = async function getTags() {
       .then((querySnapshot) => {
         querySnapshot.forEach((data) => {
           hobbeeData.push(data.data());
-          // FIXME: Objectじゃなくてarrayにして hobbeeData.push(data.data())のほうが使いやすいかも
-          // なるほど修正やりますか??
-          // issue投げて今度だな それですね!!
         });
       })
       .catch((e) => {


### PR DESCRIPTION
## 変更内容
前回の授業で、DB構造を決定した後、トップレベルのタグしか取ってこれてなくて、関連タグがまだだったから取得できるようにした。
HobbyNode.vueに渡す部分も記述したから、不格好だけど描画までできるようになった。

Miroの11/20のIn progressにある「firebaseから情報をとってくる(firebaseとの接続)」の部分！

＜スクリーンショット＞
 ![image](https://user-images.githubusercontent.com/47709871/99874708-5a981980-2c2d-11eb-82a2-ee92e28795e7.png)

レビューお願いします！