### PR TITLE
[update] relevanceのインクリメントを実装。存在しない場合は関連サブコレクションを新規作成する。

### DIFF
--- a/components/GraphSvg.vue
+++ b/components/GraphSvg.vue
@@ -10,7 +10,7 @@
           stroke="#333333"
           :stroke-width="node.relevance+ 'px'"
         />
-        <nuxt-link :to="'/' + node.id + '/graph'">
+        <nuxt-link :to="'/' + node.id + '/graph?from='+targetNode.id">
           <circle
             :r="r"
             :cx="

--- a/components/GraphSvg.vue
+++ b/components/GraphSvg.vue
@@ -123,6 +123,7 @@ export default {
     strokeWidth: function (target) {
       let max = Math.max(...this.relativeNodes.map((node) => node.relevance));
       let min = Math.min(...this.relativeNodes.map((node) => node.relevance));
+      let ratio = max === min ? 0 : (target.relevance - min) / (max - min);
       // 関連趣味のrelevanceが[13, 43, 28, 134, 55]、基本の太さが10、最大で5倍まで太くなるとすると
       // (relevance=43の趣味との線の太さ)
       // = 基本の太さ + 最大で何倍の太さを加えるか * 関連趣味の中での相対的な割合
@@ -135,10 +136,9 @@ export default {
       // 以上の計算で太さが10〜60の間に収まる
       return (
         this.nodeParam.LINE_WEIGHT +
-        (this.nodeParam.LINE_WEIGHT *
+        this.nodeParam.LINE_WEIGHT *
           this.nodeParam.MAX_STROKE_WIDTH_RATIO *
-          (target.relevance - min)) /
-          (max - min)
+          ratio
       );
     },
   },

--- a/consts/graphParameters.js
+++ b/consts/graphParameters.js
@@ -1,0 +1,7 @@
+export default {
+  "RADIUS": 100,
+  "DISTANCE": 250,
+  "TEXT_SHIFT_HEIGHT": 15,
+  "LINE_WEIGHT": 10,
+  "MAX_STROKE_WIDTH_RATIO": 5,
+}

--- a/pages/_nodeId/graph.vue
+++ b/pages/_nodeId/graph.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <nuxt-link to="/">トップへ戻る</nuxt-link>
-    <GraphSvg 
+    <GraphSvg
       :targetNode="targetTag"
       :relativeNodes="relativeTags"
       :name="name"
@@ -20,6 +20,14 @@ export default {
       targetTag: targetTag,
       relativeTags: relativeTags
     };
+  },
+
+  async created() {
+    const fromTagId = this.$route.query.from;
+    if (fromTagId) {
+      const fromTag = await this.$getTag(fromTagId);
+      await this.$incrementRelevance(fromTag, this.targetTag);
+    }
   }
 };
 </script>


### PR DESCRIPTION
## 変更内容
![image](https://user-images.githubusercontent.com/45584045/101598697-e71f4600-3a3b-11eb-8f15-52d2e96e1c08.png)
![image](https://user-images.githubusercontent.com/45584045/101598706-e981a000-3a3b-11eb-9214-a7bf7f80cdc3.png)
ゴルフと釣りを複数回移動することでインクリメントがなされた。
![image](https://user-images.githubusercontent.com/45584045/101598832-16ce4e00-3a3c-11eb-913b-1527226a524f.png)
コーヒーから(ランダムにより)ゴルフに遷移した場合(元々関連がない場合は新規作成する)
## Issue
#46 

