### PR TITLE
Feature/#43/drafts new

### DIFF
--- a/pages/drafts/new.vue
+++ b/pages/drafts/new.vue
@@ -54,20 +54,35 @@ export default {
     submit: async function (event) {
       let timestamp = await this.$getFirebaseTimestamp();
       let article = {
-        // registerArticle()を呼ぶとidが自動的に振られるようになっている
-        id: null,
-        title: this.title,
-        body: this.content,
-        // FIXME: 著者名を入力フォームから取得する
-        author: "名無しさん",
-        createdAt: timestamp,
-        updatedAt: timestamp,
-        // FIXME: 入力フォームから取得したタグ名を元にタグIDを取得して配列に格納する
-        // 仮データとしてサッカーのタグを選択している
-        // tags: ["4qqOzg7eEx2vsBIcjTTq"],
-       tags: [{ id: "4qqOzg7eEx2vsBIcjTTq", name: "サッカー" }],
-      };
-      alert(`以下の内容で送信しますか？\n${this.content}`);
+          id: null,
+          title: this.title,
+          body: this.content,
+          // FIXME: 著者名を入力フォームから取得する
+          author: "名無しさん",
+          createdAt: timestamp,
+          updatedAt: timestamp}
+      let existingTag = await this.$getExistingTag(this.tags)
+      console.log(existingTag)
+
+      alert(`以下の内容で投稿しますか？\n${this.title}`);
+
+      if (existingTag == null) {
+        //新規登録
+        console.log("existing tag is null")
+        // let documentRef = await this.$createTag(this.tags)
+        // console.log("documentRef is .." +  documentRef)
+        // article["tags"] = [{id: documentRef.id, name: this.tags}]
+        
+      }else{
+        article["tags"] = [{ id: existingTag.id, name: existingTag.name }];
+        console.log("article tags is...." + article.tags);
+          // FIXME: 入力フォームから取得したタグ名を元にタグIDを取得して配列に格納する
+          // 仮データとしてサッカーのタグを選択している
+          // tags: ["4qqOzg7eEx2vsBIcjTTq"],
+        //tagのvolumeを増やす
+        this.$incrementArticlesCount(existingTag.id)
+      }
+
       await this.$registerArticle(article);
     },
   },

--- a/pages/drafts/new.vue
+++ b/pages/drafts/new.vue
@@ -69,9 +69,9 @@ export default {
       if (existingTag == null) {
         //新規登録
         console.log("existing tag is null")
-        // let documentRef = await this.$createTag(this.tags)
-        // console.log("documentRef is .." +  documentRef)
-        // article["tags"] = [{id: documentRef.id, name: this.tags}]
+        let documentRefId = await this.$createTag(this.tags)
+        console.log("documentRefid .." + documentRefId)
+        article["tags"] = [{id: documentRefId, name: this.tags}]
         
       }else{
         article["tags"] = [{ id: existingTag.id, name: existingTag.name }];
@@ -84,6 +84,7 @@ export default {
       }
 
       await this.$registerArticle(article);
+      this.$router.push('/');
     },
   },
 };

--- a/pages/drafts/new.vue
+++ b/pages/drafts/new.vue
@@ -70,12 +70,10 @@ export default {
         //新規登録
         console.log("existing tag is null")
         let documentRefId = await this.$createTag(this.tags)
-        console.log("documentRefid .." + documentRefId)
         article["tags"] = [documentRefId]
         
       }else{
         article["tags"] = [existingTag.id];
-        console.log("article tags is...." + article.tags);
           // FIXME: 入力フォームから取得したタグ名を元にタグIDを取得して配列に格納する
           // 仮データとしてサッカーのタグを選択している
           // tags: ["4qqOzg7eEx2vsBIcjTTq"],

--- a/pages/drafts/new.vue
+++ b/pages/drafts/new.vue
@@ -71,10 +71,10 @@ export default {
         console.log("existing tag is null")
         let documentRefId = await this.$createTag(this.tags)
         console.log("documentRefid .." + documentRefId)
-        article["tags"] = [{id: documentRefId, name: this.tags}]
+        article["tags"] = [documentRefId]
         
       }else{
-        article["tags"] = [{ id: existingTag.id, name: existingTag.name }];
+        article["tags"] = [existingTag.id];
         console.log("article tags is...." + article.tags);
           // FIXME: 入力フォームから取得したタグ名を元にタグIDを取得して配列に格納する
           // 仮データとしてサッカーのタグを選択している

--- a/plugins/firebaseUtils.js
+++ b/plugins/firebaseUtils.js
@@ -108,7 +108,7 @@ Vue.prototype.$registerArticle = async function registerArticle(article) {
   ref
     .add(article)
     .then(newArticle => {
-      con
+      // con
       ref.doc(newArticle.id).update({
         id: newArticle.id
       });
@@ -140,17 +140,19 @@ Vue.prototype.$getExistingTag = async function getExistingTag(query) {
 
 //趣味の記事が増えた、かつ趣味が新規の時、趣味データを作成
 Vue.prototype.$createTag = async function createTag(tagName) {
-  let ref = db.collection("tags").doc();
-  ref
+  // ref = db.collection("tags").doc();
+  let refId = db.collection("tags").doc().id;
+  return await db.collection("tags")
+    .doc(refId)
     .set({
       articlesCount: 1,
-      id: ref.id,
+      id: refId,
       name: tagName,
       volume: 100
     })
-    .then(function() {
+    .then(function(docRef) {
       console.log("Document successfully written!");
-      return ref;
+      return refId;
     })
     .catch(function(error) {
       console.error("Error writing document: ", error);

--- a/plugins/firebaseUtils.js
+++ b/plugins/firebaseUtils.js
@@ -218,6 +218,33 @@ Vue.prototype.$incrementRelevance = async (fromTag, currentTag) => {
     });
 };
 
+Vue.prototype.$getSuggestions = async function getSuggestions() {
+  return await db
+    .collection("tagSuggestions")
+    .doc("suggestions")
+    .get()
+    .then(data => {
+      return data.data();
+    })
+    .catch(e => {
+      console.error(e);
+    });
+};
+
+Vue.prototype.$addTagSuggestions = async function addTagSuggestions(newTagSuggestions){
+  db.collection("tagSuggestions")
+  .doc("suggestions")
+  .set({
+    tagSuggestions: newTagSuggestions
+  })
+  .then(function (){
+    console.log("newTagSuggestions write success!")
+  })
+  .catch(e => {
+    console.error(e);
+  });
+}
+
 export default context => {
   context.$getTags = Vue.prototype.$getTags;
   context.$getRelativeTags = Vue.prototype.$getRelativeTags;
@@ -225,6 +252,8 @@ export default context => {
   context.$getExistingTag = Vue.prototype.$getExistingTag;
   context.$createTag = Vue.prototype.$createTag;
   context.$incrementArticlesCount = Vue.prototype.$incrementArticlesCount;
+  context.$getSuggestions = Vue.prototype.$getSuggestions;
+  context.$addTagSuggestions = Vue.prototype.$addTagSuggestions;
 };
 // 現在時刻を取得する
 Vue.prototype.$getFirebaseTimestamp = async function getFirebaseTimestamp() {


### PR DESCRIPTION
## 変更内容
既存の趣味だったら、タグをサジェストしてくれるようになりました！
既存の趣味は、firestoreのルートに
tagSuggestions/suggestions というドキュメントを作って、それに配列としてまとめて
```
{
tagSuggestions: [サッカー,バドミントン,フットサル...]
}
```
みたいになってます！

新しい趣味が追加されるたびに、このドキュメントにも追加されます！

## Issue
#43 