### PR TITLE
関連タグが少ないときランダムタグを多めに円周上に表示

### DIFF
--- a/components/GraphSvg.vue
+++ b/components/GraphSvg.vue
@@ -12,7 +12,8 @@
       <input v-model="viewBoxHeight" type="number" step="10" min="0" />
     </form>
     -->
-    <svg :viewBox="
+    <svg
+      :viewBox="
         viewBoxX + ' ' + viewBoxY + ' ' + viewBoxWidth + ' ' + viewBoxHeight
       "
       :width="width"
@@ -35,19 +36,19 @@
             :y1="y"
             :x2="
               x +
-                nodeParam.DISTANCE *
-                  reverseIndex(tierIndex) *
-                  Math.cos(
-                    radOfNode(nodeIndex, reverseIndex(tierIndex) - 1, nodes)
-                  )
+              nodeParam.DISTANCE *
+                reverseIndex(tierIndex) *
+                Math.cos(
+                  radOfNode(nodeIndex, reverseIndex(tierIndex) - 1, nodes)
+                )
             "
             :y2="
               y +
-                nodeParam.DISTANCE *
-                  reverseIndex(tierIndex) *
-                  Math.sin(
-                    radOfNode(nodeIndex, reverseIndex(tierIndex) - 1, nodes)
-                  )
+              nodeParam.DISTANCE *
+                reverseIndex(tierIndex) *
+                Math.sin(
+                  radOfNode(nodeIndex, reverseIndex(tierIndex) - 1, nodes)
+                )
             "
             stroke="#eaffd0"
             :stroke-width="`${node.strokeWidth}px`"
@@ -55,17 +56,17 @@
           <nuxt-link
             :to="
               '/' +
-                node.id +
-                '/graph?from=' +
-                targetNode.id +
-                '&viewBoxX=' +
-                viewBoxX +
-                '&viewBoxY=' +
-                viewBoxY +
-                '&viewBoxWidth=' +
-                viewBoxWidth +
-                '&viewBoxHeight=' +
-                viewBoxHeight
+              node.id +
+              '/graph?from=' +
+              targetNode.id +
+              '&viewBoxX=' +
+              viewBoxX +
+              '&viewBoxY=' +
+              viewBoxY +
+              '&viewBoxWidth=' +
+              viewBoxWidth +
+              '&viewBoxHeight=' +
+              viewBoxHeight
             "
           >
             <!-- 関連趣味のノード -->
@@ -73,20 +74,21 @@
               :r="node.radius"
               :cx="
                 x +
-                  nodeParam.DISTANCE *
-                    reverseIndex(tierIndex) *
-                    Math.cos(
-                      radOfNode(nodeIndex, reverseIndex(tierIndex) - 1, nodes)
-                    )
+                nodeParam.DISTANCE *
+                  reverseIndex(tierIndex) *
+                  Math.cos(
+                    radOfNode(nodeIndex, reverseIndex(tierIndex) - 1, nodes)
+                  )
               "
               :cy="
                 y +
-                  nodeParam.DISTANCE *
-                    reverseIndex(tierIndex) *
-                    Math.sin(
-                      radOfNode(nodeIndex, reverseIndex(tierIndex) - 1, nodes)
-                    )
+                nodeParam.DISTANCE *
+                  reverseIndex(tierIndex) *
+                  Math.sin(
+                    radOfNode(nodeIndex, reverseIndex(tierIndex) - 1, nodes)
+                  )
               "
+              :class="{randomTags:node.isRandom}"
             ></circle>
             <text
               :x="x + (nodeIndex + 1) * 200"
@@ -95,23 +97,23 @@
               dominant-baseline="central"
               style="font-size: 24px; fill: #111111"
             >
-              <!-- 関連趣味名 -->
+              <!-- 関連趣味名 .randomTags -->
               <tspan
                 :x="
                   x +
-                    nodeParam.DISTANCE *
-                      reverseIndex(tierIndex) *
-                      Math.cos(
-                        radOfNode(nodeIndex, reverseIndex(tierIndex) - 1, nodes)
-                      )
+                  nodeParam.DISTANCE *
+                    reverseIndex(tierIndex) *
+                    Math.cos(
+                      radOfNode(nodeIndex, reverseIndex(tierIndex) - 1, nodes)
+                    )
                 "
                 :y="
                   y +
-                    nodeParam.DISTANCE *
-                      reverseIndex(tierIndex) *
-                      Math.sin(
-                        radOfNode(nodeIndex, reverseIndex(tierIndex) - 1, nodes)
-                      )
+                  nodeParam.DISTANCE *
+                    reverseIndex(tierIndex) *
+                    Math.sin(
+                      radOfNode(nodeIndex, reverseIndex(tierIndex) - 1, nodes)
+                    )
                 "
               >
                 {{ node.name }}
@@ -175,7 +177,7 @@ export default {
     vbX: { type: Number, default: 0 },
     vbY: { type: Number, default: -200 },
     vbWidth: { type: Number, default: window.innerWidth },
-    vbHeight: { type: Number, default: window.innerHeight }
+    vbHeight: { type: Number, default: window.innerHeight },
   },
   data() {
     return {
@@ -194,15 +196,15 @@ export default {
       mouseY: 0,
       prev_pos: {
         x: 0,
-        y: 0
-      }
+        y: 0,
+      },
     };
   },
   computed: {
     // 定数を取り出す算出プロパティ
     nodeParam() {
       return graphParameters;
-    }
+    },
   },
   async created() {
     this.viewBoxX = this.vbX;
@@ -210,6 +212,13 @@ export default {
     this.viewBoxWidth = this.vbWidth;
     this.viewBoxHeight = this.vbHeight;
     window.addEventListener("resize", this.handleResize);
+    this.randomTags.forEach((randomTag) => {
+      randomTag["isRandom"] = true;
+      randomTag["relavance"] = 0
+    });
+    // console.debug("converted randomtags" + JSON.stringify(this.randomTags));
+    // relative randomをconcatしたい
+    this.relativeNodes = this.relativeNodes.concat(this.randomTags)
     let _relativeNodes = await this.calcRadius(this.relativeNodes);
     _relativeNodes = await this.calcStrokeWidth(_relativeNodes);
     this.splittedRelativeNodes = this.splitRelativeNodes(_relativeNodes);
@@ -220,17 +229,21 @@ export default {
     this.y = this.height / 2;
     window.resizeTo(5000, 5000);
   },
-  beforeDestroy: function() {
+  beforeDestroy: function () {
     window.removeEventListener("resize", this.handleResize);
     window.removeEventListener("wheel", this.scrollControl, { passive: false });
-    window.removeEventListener("touchmove", this.scrollControl, { passive: false });
-    window.removeEventListener("keydown", this.scrollControl, { passive: false });
+    window.removeEventListener("touchmove", this.scrollControl, {
+      passive: false,
+    });
+    window.removeEventListener("keydown", this.scrollControl, {
+      passive: false,
+    });
   },
   methods: {
     clickEvent(event) {
       console.log(`Clicked (${event.clientX}, ${event.clientY})`);
     },
-    touchstart: function(event) {
+    touchstart: function (event) {
       this.isMousedown = true;
       console.log("touch start:%d,%d", event.offsetX, event.offsetY);
       this.prev_pos.x = event.offsetX;
@@ -238,7 +251,7 @@ export default {
       this.mouseX = event.offsetX;
       this.mouseY = event.offsetY;
     },
-    touchmove: function(event) {
+    touchmove: function (event) {
       // 押下中だったら
       if (this.isMousedown) {
         // 前回座標との差分を算出
@@ -254,11 +267,11 @@ export default {
         this.prev_pos.y = event.offsetY;
       }
     },
-    touchend: function(event) {
+    touchend: function (event) {
       this.isMousedown = false;
       console.log("touch end");
     },
-    mouseWheel: function(event) {
+    mouseWheel: function (event) {
       console.log(`mouse wheel ${event.deltaMode}`);
       if (event.deltaY > 0) {
         // zoom in
@@ -270,30 +283,30 @@ export default {
         this.viewBoxHeight = (this.viewBoxHeight * (500 - event.deltaY)) / 500;
       }
     },
-    scrollControl: function(event) {
+    scrollControl: function (event) {
       event.preventDefault();
     },
-    noScroll: function(event) {
+    noScroll: function (event) {
       window.addEventListener("wheel", this.scrollControl, { passive: false });
       window.addEventListener("touchmove", this.scrollControl, {
-        passive: false
+        passive: false,
       });
       window.addEventListener("keydown", this.scrollControl, {
-        passive: false
+        passive: false,
       });
     },
-    handleResize: function() {
+    handleResize: function () {
       this.width = window.innerWidth;
       this.height = window.innerHeight;
       this.x = this.width / 2;
       this.y = this.height / 2;
     },
     // 関連を表す線の太さを計算する
-    calcStrokeWidth: async function(nodes) {
-      const max = Math.max(...nodes.map(node => node.relevance));
-      const min = Math.min(...nodes.map(node => node.relevance));
+    calcStrokeWidth: async function (nodes) {
+      const max = Math.max(...nodes.map((node) => node.relevance));
+      const min = Math.min(...nodes.map((node) => node.relevance));
       const _nodes = await Promise.all(
-        nodes.map(async node => {
+        nodes.map(async (node) => {
           const ratio = max === min ? 0 : (node.relevance - min) / (max - min);
           node.strokeWidth =
             this.nodeParam.LINE_WEIGHT +
@@ -306,15 +319,15 @@ export default {
       return _nodes;
     },
     // 全関連ノードの描画時の半径を計算する
-    calcRadius: async function(nodes) {
+    calcRadius: async function (nodes) {
       // tagドキュメントを全て取得
       const allTags = await this.$getTags();
       // volumeの最大・最小値を計算
-      const max = Math.max(...allTags.map(tag => tag.volume));
-      const min = Math.min(...allTags.map(tag => tag.volume));
+      const max = Math.max(...allTags.map((tag) => tag.volume));
+      const min = Math.min(...allTags.map((tag) => tag.volume));
       // 各ノードについて半径を計算する
       const _nodes = await Promise.all(
-        nodes.map(async node => {
+        nodes.map(async (node) => {
           const tag = await this.$getTag(node.id);
           // min-max正規化
           let increaseRatio =
@@ -329,7 +342,7 @@ export default {
       return _nodes;
     },
     // ノードを同心円上に配置するときの配置数を返すジェネレータ
-    nodeNumGenerator: function*(totalNum) {
+    nodeNumGenerator: function* (totalNum) {
       let remainingCount = totalNum;
       //for (let i = 1; i <= this.nodeParam.MAX_RELATIVE_NODE_CIRCLES; i++) {
       for (let i = 1; i <= 10; i++) {
@@ -345,7 +358,7 @@ export default {
     },
     // 関連ノードを分割して、ノードの2次元配列にする
     // e.g. splitRelativeNodes({ノード} * 13) -> {[ノード} * 4, ノード * 8, ノード * 1]
-    splitRelativeNodes: function(nodes) {
+    splitRelativeNodes: function (nodes) {
       let relativeNodesCopy = JSON.parse(JSON.stringify(nodes));
       // 関連度順に降順ソート
       relativeNodesCopy.sort((a, b) => b.relevance - a.relevance);
@@ -379,8 +392,8 @@ export default {
     reverseIndex(index) {
       return this.splittedRelativeNodes.length - index;
       // return 1,2,3,...
-    }
-  }
+    },
+  },
 };
 </script>
 

--- a/components/GraphSvg.vue
+++ b/components/GraphSvg.vue
@@ -26,7 +26,7 @@
     >
       <!-- 関連趣味に関する描画のループ -->
       <g
-        v-for="(nodes, tierIndex) in splittedRelativeNodes"
+        v-for="(nodes, tierIndex) in scatteredNodes"
         :key="'t-' + tierIndex"
       >
         <g v-for="(node, nodeIndex) in nodes" :key="'n-' + nodeIndex">
@@ -141,26 +141,6 @@
           </tspan>
         </text>
       </nuxt-link>
-      <!-- ランダムのノード -->
-      <g v-for="(node, index) in randomTags" :key="index">
-        <nuxt-link :to="'/' + node.id + '/graph?from=' + targetNode.id">
-          <circle
-            :r="nodeParam.RADIUS"
-            :cx="x + (index + 1) * 250"
-            :cy="y + 300"
-            class="randomTags"
-          ></circle>
-          <text
-            text-anchor="middle"
-            dominant-baseline="central"
-            style="font-size: 24px; fill: #111111"
-          >
-            <tspan :x="x + (index + 1) * 250" :y="y + 300">
-              {{ node.name }}
-            </tspan>
-          </text>
-        </nuxt-link>
-      </g>
     </svg>
   </div>
 </template>
@@ -191,7 +171,7 @@ export default {
       viewBoxY: -200,
       viewBoxWidth: 1500,
       viewBoxHeight: 1500,
-      splittedRelativeNodes: null,
+      scatteredNodes: null,
       mouseX: 0,
       mouseY: 0,
       prev_pos: {
@@ -212,16 +192,17 @@ export default {
     this.viewBoxWidth = this.vbWidth;
     this.viewBoxHeight = this.vbHeight;
     window.addEventListener("resize", this.handleResize);
-    this.randomTags.forEach((randomTag) => {
+    let _randomTags = this.randomTags.map((randomTag) => {
       randomTag["isRandom"] = true;
-      randomTag["relavance"] = 0
+      randomTag["relavance"] = 1
+      return randomTag
     });
     // console.debug("converted randomtags" + JSON.stringify(this.randomTags));
     // relative randomをconcatしたい
-    this.relativeNodes = this.relativeNodes.concat(this.randomTags)
-    let _relativeNodes = await this.calcRadius(this.relativeNodes);
+    let _relativeNodes = this.relativeNodes.concat(_randomTags)
+    _relativeNodes = await this.calcRadius(_relativeNodes);
     _relativeNodes = await this.calcStrokeWidth(_relativeNodes);
-    this.splittedRelativeNodes = this.splitRelativeNodes(_relativeNodes);
+    this.scatteredNodes = this.scatterNodes(_relativeNodes);
     this.noScroll();
   },
   mounted() {
@@ -357,17 +338,17 @@ export default {
       }
     },
     // 関連ノードを分割して、ノードの2次元配列にする
-    // e.g. splitRelativeNodes({ノード} * 13) -> {[ノード} * 4, ノード * 8, ノード * 1]
-    splitRelativeNodes: function (nodes) {
-      let relativeNodesCopy = JSON.parse(JSON.stringify(nodes));
+    // e.g. scatterNodes({ノード} * 13) -> {[ノード} * 4, ノード * 8, ノード * 1]
+    scatterNodes: function (nodes) {
+      let copyOfNodes = JSON.parse(JSON.stringify(nodes));
       // 関連度順に降順ソート
-      relativeNodesCopy.sort((a, b) => b.relevance - a.relevance);
+      copyOfNodes.sort((a, b) => b.relevance - a.relevance);
       const gen = this.nodeNumGenerator(nodes.length);
-      let splittedNodes = [];
+      let _scatteredNodes = [];
       while (true) {
         let nodeNum = gen.next();
-        console.debug("nodeNum : " + nodeNum.value);
-        splittedNodes.push(relativeNodesCopy.splice(0, nodeNum.value));
+        // console.debug("nodeNum : " + nodeNum.value);
+        _scatteredNodes.push(copyOfNodes.splice(0, nodeNum.value));
         if (nodeNum.done) {
           // 最後のノード数を返すときにdoneプロパティがtrueになるのでそこで終了
           break;
@@ -375,11 +356,11 @@ export default {
       }
       console.debug(
         `Splitted relativeNodes (created() in GraphSvg.vue): ${JSON.stringify(
-          splittedNodes
+          _scatteredNodes
         )}`
       );
       // 外側に配置するノードから順にソートする
-      return splittedNodes.reverse();
+      return _scatteredNodes.reverse();
     },
     // ノード数を考慮した角度を決める
     radOfNode(nodeIndex, tierIndex, nodes) {
@@ -390,7 +371,7 @@ export default {
     },
     // インデックスを逆順にする
     reverseIndex(index) {
-      return this.splittedRelativeNodes.length - index;
+      return this.scatteredNodes.length - index;
       // return 1,2,3,...
     },
   },

--- a/pages/_nodeId/graph.vue
+++ b/pages/_nodeId/graph.vue
@@ -10,8 +10,9 @@
     async asyncData({ params, $getTag, $getRelativeTags, $getRandomTags }) {
       const targetTag = await $getTag(params.nodeId);
       const relativeTags = await $getRelativeTags(targetTag.id);
+      let minAllTags = 12;
       const randomTags = await $getRandomTags(
-        2,
+        relativeTags.length < minAllTags ? minAllTags - relativeTags.length : 3,
         relativeTags.concat([targetTag]).map(tag => tag.id)
       );
       return {

--- a/pages/_nodeId/graph.vue
+++ b/pages/_nodeId/graph.vue
@@ -10,9 +10,10 @@
     async asyncData({ params, $getTag, $getRelativeTags, $getRandomTags }) {
       const targetTag = await $getTag(params.nodeId);
       const relativeTags = await $getRelativeTags(targetTag.id);
-      let minAllTags = 12;
+      const minAllTags = 12;
+      const minRandomTags = 3;
       const randomTags = await $getRandomTags(
-        relativeTags.length < minAllTags ? minAllTags - relativeTags.length : 3,
+        relativeTags.length <= minAllTags - minRandomTags ? minAllTags - relativeTags.length : minRandomTags,
         relativeTags.concat([targetTag]).map(tag => tag.id)
       );
       return {


### PR DESCRIPTION
## やったこと
- randomのTagも円周上に表示できるようになりました。
- relativeNodesが少ないときはRandomTagsを多めに表示
- relativeとrandomを一つのArrayに入れたことに伴い、変数名・メソッド名のリファクタリングをしました。
![image](https://user-images.githubusercontent.com/45584045/103337882-f5530600-4abf-11eb-99c4-67732ab219fc.png)
![image](https://user-images.githubusercontent.com/45584045/103337889-fb48e700-4abf-11eb-8f7b-e31afde775bd.png)

## 共同作業
@mei28 
close #66 