### PR TITLE
沼削除画面・volume計算機能の追加

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           github_token: ${{ secrets.TOKEN }}
       - name: Run eslint
-        run: yarn lint
+        run: yarn lint-fix

--- a/components/GraphSvg.vue
+++ b/components/GraphSvg.vue
@@ -1,41 +1,29 @@
 <template>
   <div>
-    <svg
-      :viewBox="
+    <svg :viewBox="
         viewBoxX + ' ' + viewBoxY + ' ' + viewBoxWidth + ' ' + viewBoxHeight
-      "
-      :width="width"
-      :height="height"
-    >
-    <g id = 'scene'>
-      <!-- 関連趣味に関する描画のループ -->
-      <g v-for="(nodes, tierIndex) in scatteredNodes" :key="'t-' + tierIndex">
-        <g v-for="(node, nodeIndex) in nodes" :key="'n-' + nodeIndex">
-          <!-- ノード間をつなぐ線 -->
-          <line
-            :x1="x"
-            :y1="y"
-            :x2="
+      " :width="width" :height="height">
+      <g id='scene'>
+        <!-- 関連趣味に関する描画のループ -->
+        <g v-for="(nodes, tierIndex) in scatteredNodes" :key="'t-' + tierIndex">
+          <g v-for="(node, nodeIndex) in nodes" :key="'n-' + nodeIndex">
+            <!-- ノード間をつなぐ線 -->
+            <line :x1="x" :y1="y" :x2="
               x +
               nodeParam.DISTANCE *
                 reverseIndex(tierIndex) *
                 Math.cos(
                   radOfNode(nodeIndex, reverseIndex(tierIndex) - 1, nodes)
                 )
-            "
-            :y2="
+            " :y2="
               y +
               nodeParam.DISTANCE *
                 reverseIndex(tierIndex) *
                 Math.sin(
                   radOfNode(nodeIndex, reverseIndex(tierIndex) - 1, nodes)
                 )
-            "
-            stroke="#eaffd0"
-            :stroke-width="`${node.strokeWidth}px`"
-          />
-          <nuxt-link
-            :to="
+            " stroke="#eaffd0" :stroke-width="`${node.strokeWidth}px`" />
+            <nuxt-link :to="
               '/' +
               node.id +
               '/graph?from=' +
@@ -48,259 +36,241 @@
               viewBoxWidth +
               '&viewBoxHeight=' +
               viewBoxHeight
-            "
-          >
-            <!-- 関連趣味のノード -->
-            <circle
-              :r="node.radius"
-              :cx="
+            ">
+              <!-- 関連趣味のノード -->
+              <circle :r="node.radius" :cx="
                 x +
                 nodeParam.DISTANCE *
                   reverseIndex(tierIndex) *
                   Math.cos(
                     radOfNode(nodeIndex, reverseIndex(tierIndex) - 1, nodes)
                   )
-              "
-              :cy="
+              " :cy="
                 y +
                 nodeParam.DISTANCE *
                   reverseIndex(tierIndex) *
                   Math.sin(
                     radOfNode(nodeIndex, reverseIndex(tierIndex) - 1, nodes)
                   )
-              "
-              :class="{ randomTags: node.isRandom }"
-            ></circle>
-            <text
-              :x="x + (nodeIndex + 1) * 200"
-              :y="y + (nodeIndex + 1) * 200"
-              text-anchor="middle"
-              dominant-baseline="central"
-              style="font-size: 24px; fill: #111111"
-            >
-              <!-- 関連趣味名 .randomTags -->
-              <tspan
-                :x="
+              " :class="{ randomTags: node.isRandom }"></circle>
+              <text :x="x + (nodeIndex + 1) * 200" :y="y + (nodeIndex + 1) * 200" text-anchor="middle"
+                dominant-baseline="central" style="font-size: 24px; fill: #111111">
+                <!-- 関連趣味名 .randomTags -->
+                <tspan :x="
                   x +
                   nodeParam.DISTANCE *
                     reverseIndex(tierIndex) *
                     Math.cos(
                       radOfNode(nodeIndex, reverseIndex(tierIndex) - 1, nodes)
                     )
-                "
-                :y="
+                " :y="
                   y +
                   nodeParam.DISTANCE *
                     reverseIndex(tierIndex) *
                     Math.sin(
                       radOfNode(nodeIndex, reverseIndex(tierIndex) - 1, nodes)
                     )
-                "
-              >
-                {{ node.name }}
-              </tspan>
-            </text>
-          </nuxt-link>
+                ">
+                  {{ node.name }}
+                </tspan>
+              </text>
+            </nuxt-link>
+          </g>
         </g>
+        <!-- 現在フォーカスしている趣味のノードと名前の描画 -->
+        <nuxt-link :to="'/' + targetNode.id + '/list'">
+          <circle :r="nodeParam.RADIUS" :cx="x" :cy="y" style="fill: #f38181"></circle>
+          <text text-anchor="middle" dominant-baseline="central" style="font-size: 24px; fill: #111111">
+            <tspan :x="x" :y="y - nodeParam.TEXT_SHIFT_HEIGHT">{{ name }}</tspan>
+            <tspan :x="x" :y="y + nodeParam.TEXT_SHIFT_HEIGHT">
+              の沼を覗く？
+            </tspan>
+          </text>
+        </nuxt-link>
       </g>
-      <!-- 現在フォーカスしている趣味のノードと名前の描画 -->
-      <nuxt-link :to="'/' + targetNode.id + '/list'">
-        <circle
-          :r="nodeParam.RADIUS"
-          :cx="x"
-          :cy="y"
-          style="fill: #f38181"
-        ></circle>
-        <text
-          text-anchor="middle"
-          dominant-baseline="central"
-          style="font-size: 24px; fill: #111111"
-        >
-          <tspan :x="x" :y="y - nodeParam.TEXT_SHIFT_HEIGHT">{{ name }}</tspan>
-          <tspan :x="x" :y="y + nodeParam.TEXT_SHIFT_HEIGHT">
-            の沼を覗く？
-          </tspan>
-        </text>
-      </nuxt-link>
-    </g>
     </svg>
   </div>
 </template>
 
 <script>
-import graphParameters from "@/consts/graphParameters";
+  import graphParameters from "@/consts/graphParameters";
 
-export default {
-  props: {
-    targetNode: { type: Object, default: new Object() },
-    relativeNodes: { type: Array, default: new Array() },
-    name: { type: String, default: "" },
-    randomTags: { type: Array, default: new Array() },
-    vbX: { type: Number, default: 0 },
-    vbY: { type: Number, default: -200 },
-    vbWidth: { type: Number, default: window.innerWidth },
-    vbHeight: { type: Number, default: window.innerHeight },
-  },
-  data() {
-    return {
-      active: false,
-      width: window.innerWidth,
-      height: window.innerHeight,
-      x: 0,
-      y: 0,
-      viewBoxX: 0,
-      viewBoxY: -200,
-      viewBoxWidth: 1500,
-      viewBoxHeight: 1500,
-      scatteredNodes: null,
-    };
-  },
-  computed: {
-    // 定数を取り出す算出プロパティ
-    nodeParam() {
-      return graphParameters;
+  export default {
+    props: {
+      targetNode: { type: Object, default: new Object() },
+      relativeNodes: { type: Array, default: new Array() },
+      name: { type: String, default: "" },
+      randomTags: { type: Array, default: new Array() },
+      vbX: { type: Number, default: 0 },
+      vbY: { type: Number, default: -200 },
+      vbWidth: { type: Number, default: window.innerWidth },
+      vbHeight: { type: Number, default: window.innerHeight },
     },
-  },
-  async created() {
-    this.viewBoxX = this.vbX;
-    this.viewBoxY = this.vbY;
-    this.viewBoxWidth = this.vbWidth;
-    this.viewBoxHeight = this.vbHeight;
-    let _randomTags = this.randomTags.map((randomTag) => {
-      randomTag["isRandom"] = true;
-      randomTag["relavance"] = 1;
-      return randomTag;
-    });
-    // console.debug("converted randomtags" + JSON.stringify(this.randomTags));
-    // relative randomをconcatしたい
-    let _relativeNodes = this.relativeNodes.concat(_randomTags);
-    _relativeNodes = await this.calcRadius(_relativeNodes);
-    _relativeNodes = await this.calcStrokeWidth(_relativeNodes);
-    this.scatteredNodes = this.scatterNodes(_relativeNodes);
-  },
-  mounted() {
-    this.x = this.width / 2;
-    this.y = this.height / 2;
-    var panzoom = require('panzoom')
-    var element = document.getElementById('scene')
-    panzoom(element)
-  },
-  methods: {
-    // 関連を表す線の太さを計算する
-    calcStrokeWidth: async function (nodes) {
-      const max = Math.max(...nodes.map((node) => node.relevance));
-      const min = Math.min(...nodes.map((node) => node.relevance));
-      // FIXME: ランダムなタグが関連度nullなので、nullの場合を考慮しないと線の太さがnullになる
-      // FIXME: 非同期処理する必要ないかも
-      const _nodes = await Promise.all(
-        nodes.map(async (node) => {
-          const ratio = max === min ? 0 : (node.relevance - min) / (max - min);
-          node.strokeWidth =
-            this.nodeParam.LINE_WEIGHT +
-            this.nodeParam.LINE_WEIGHT *
+    data() {
+      return {
+        active: false,
+        width: window.innerWidth,
+        height: window.innerHeight,
+        x: 0,
+        y: 0,
+        viewBoxX: 0,
+        viewBoxY: -200,
+        viewBoxWidth: 1500,
+        viewBoxHeight: 1500,
+        scatteredNodes: null,
+      };
+    },
+    computed: {
+      // 定数を取り出す算出プロパティ
+      nodeParam() {
+        return graphParameters;
+      },
+    },
+    async created() {
+      this.viewBoxX = this.vbX;
+      this.viewBoxY = this.vbY;
+      this.viewBoxWidth = this.vbWidth;
+      this.viewBoxHeight = this.vbHeight;
+      let _randomTags = this.randomTags.map((randomTag) => {
+        randomTag["isRandom"] = true;
+        randomTag["relavance"] = 1;
+        return randomTag;
+      });
+      // console.debug("converted randomtags" + JSON.stringify(this.randomTags));
+      // relative randomをconcatしたい
+      let _relativeNodes = this.relativeNodes.concat(_randomTags);
+      _relativeNodes = await this.calcRadius(_relativeNodes);
+      _relativeNodes = await this.calcStrokeWidth(_relativeNodes);
+      this.scatteredNodes = this.scatterNodes(_relativeNodes);
+    },
+    mounted() {
+      this.x = this.width / 2;
+      this.y = this.height / 2;
+      var panzoom = require('panzoom')
+      var element = document.getElementById('scene')
+      panzoom(element)
+    },
+    methods: {
+      // 関連を表す線の太さを計算する
+      calcStrokeWidth: async function (nodes) {
+        const max = Math.max(...nodes.map((node) => node.relevance));
+        const min = Math.min(...nodes.map((node) => node.relevance));
+        // FIXME: ランダムなタグが関連度nullなので、nullの場合を考慮しないと線の太さがnullになる
+        // FIXME: 非同期処理する必要ないかも
+        const _nodes = await Promise.all(
+          nodes.map(async (node) => {
+            const ratio = max === min ? 0 : (node.relevance - min) / (max - min);
+            node.strokeWidth =
+              this.nodeParam.LINE_WEIGHT +
+              this.nodeParam.LINE_WEIGHT *
               this.nodeParam.MAX_STROKE_WIDTH_RATIO *
               ratio;
-          return node;
-        })
-      );
-      return _nodes;
-    },
-    // 全関連ノードの描画時の半径を計算する
-    calcRadius: async function (nodes) {
-      // tagドキュメントを全て取得
-      const allTags = await this.$getTags();
-      // volumeの最大・最小値を計算
-      const max = Math.max(...allTags.map((tag) => tag.volume));
-      const min = Math.min(...allTags.map((tag) => tag.volume));
-      // 各ノードについて半径を計算する
-      const _nodes = await Promise.all(
-        nodes.map(async (node) => {
-          const tag = await this.$getTag(node.id);
-          // min-max正規化
-          let increaseRatio =
-            max === min ? 0 : (tag.volume - min) / (max - min);
-          // volumeに応じて半径を計算
-          node.radius =
-            this.nodeParam.RADIUS +
-            this.nodeParam.MAX_DELTA_RADIUS * increaseRatio;
-          return node;
-        })
-      );
-      return _nodes;
-    },
-    // ノードを同心円上に配置するときの配置数を返すジェネレータ
-    nodeNumGenerator: function* (totalNum) {
-      let remainingCount = totalNum;
-      //for (let i = 1; i <= this.nodeParam.MAX_RELATIVE_NODE_CIRCLES; i++) {
-      for (let i = 1; i <= 10; i++) {
-        // 内側の円から4, 8, ...と個数が増えていく
-        const nextNum = i * 4;
-        if (nextNum >= remainingCount) {
-          // 4の倍数ずつ内側から配置していったときの余りを一番外側の円に配置する
-          return remainingCount;
+            return node;
+          })
+        );
+        return _nodes;
+      },
+      // タグのボリュームを計算する
+      // FIXME: ずぶずぶ数など他のプロパティを考慮した計算式にする
+      volume: function (tag) {
+        return tag.articlesCount ? tag.articlesCount : 0;
+      },
+      // 全関連ノードの描画時の半径を計算する
+      calcRadius: async function (nodes) {
+        // tagドキュメントを全て取得
+        const allTags = await this.$getTags();
+        // volumeの最大・最小値を計算
+        const max = Math.max(...allTags.map((tag) => this.volume(tag)));
+        const min = Math.min(...allTags.map((tag) => this.volume(tag)));
+        // 各ノードについて半径を計算する
+        const _nodes = await Promise.all(
+          nodes.map(async (node) => {
+            const tag = await this.$getTag(node.id);
+            // min-max正規化
+            let increaseRatio =
+              max === min ? 0 : (this.volume(tag) - min) / (max - min);
+            // volumeに応じて半径を計算
+            node.radius =
+              this.nodeParam.RADIUS +
+              this.nodeParam.MAX_DELTA_RADIUS * increaseRatio;
+            return node;
+          })
+        );
+        return _nodes;
+      },
+      // ノードを同心円上に配置するときの配置数を返すジェネレータ
+      nodeNumGenerator: function* (totalNum) {
+        let remainingCount = totalNum;
+        //for (let i = 1; i <= this.nodeParam.MAX_RELATIVE_NODE_CIRCLES; i++) {
+        for (let i = 1; i <= 10; i++) {
+          // 内側の円から4, 8, ...と個数が増えていく
+          const nextNum = i * 4;
+          if (nextNum >= remainingCount) {
+            // 4の倍数ずつ内側から配置していったときの余りを一番外側の円に配置する
+            return remainingCount;
+          }
+          remainingCount -= nextNum;
+          yield nextNum;
         }
-        remainingCount -= nextNum;
-        yield nextNum;
-      }
-    },
-    // 関連ノードを分割して、ノードの2次元配列にする
-    // e.g. scatterNodes({ノード} * 13) -> {[ノード} * 4, ノード * 8, ノード * 1]
-    scatterNodes: function (nodes) {
-      let copyOfNodes = JSON.parse(JSON.stringify(nodes));
-      // 関連度順に降順ソート
-      copyOfNodes.sort((a, b) => b.relevance - a.relevance);
-      // 4, 8, ...という数字を返すジェネレータ
-      const gen = this.nodeNumGenerator(nodes.length);
-      // 分割後のノードの配列
-      let _scatteredNodes = [];
-      let isFinished = false;
-      for (let nodeNum = gen.next(); !isFinished; nodeNum = gen.next()) {
-        // e.g.
-        // (value, done)
-        // (4, false)
-        // (8, false)
-        // (1, true)
-        // (null, null)
+      },
+      // 関連ノードを分割して、ノードの2次元配列にする
+      // e.g. scatterNodes({ノード} * 13) -> {[ノード} * 4, ノード * 8, ノード * 1]
+      scatterNodes: function (nodes) {
+        let copyOfNodes = JSON.parse(JSON.stringify(nodes));
+        // 関連度順に降順ソート
+        copyOfNodes.sort((a, b) => b.relevance - a.relevance);
+        // 4, 8, ...という数字を返すジェネレータ
+        const gen = this.nodeNumGenerator(nodes.length);
+        // 分割後のノードの配列
+        let _scatteredNodes = [];
+        let isFinished = false;
+        for (let nodeNum = gen.next(); !isFinished; nodeNum = gen.next()) {
+          // e.g.
+          // (value, done)
+          // (4, false)
+          // (8, false)
+          // (1, true)
+          // (null, null)
 
-        // nodeNum.valueの数だけ配列に格納する
-        _scatteredNodes.push(copyOfNodes.splice(0, nodeNum.value));
-        // 上の例だと(1, true)が返ってきたらループを抜ける
-        isFinished = nodeNum.done;
-      }
-      console.debug(
-        `Splitted relativeNodes (created() in GraphSvg.vue): ${JSON.stringify(
-          _scatteredNodes
-        )}`
-      );
-      // 外側に配置するノードから順にソートする
-      return _scatteredNodes.reverse();
+          // nodeNum.valueの数だけ配列に格納する
+          _scatteredNodes.push(copyOfNodes.splice(0, nodeNum.value));
+          // 上の例だと(1, true)が返ってきたらループを抜ける
+          isFinished = nodeNum.done;
+        }
+        console.debug(
+          `Splitted relativeNodes (created() in GraphSvg.vue): ${JSON.stringify(
+            _scatteredNodes
+          )}`
+        );
+        // 外側に配置するノードから順にソートする
+        return _scatteredNodes.reverse();
+      },
+      // ノード数を考慮した角度を決める
+      radOfNode(nodeIndex, tierIndex, nodes) {
+        return (
+          (2 * Math.PI * nodeIndex + this.nodeParam.ROTATE_RADIAN * tierIndex) /
+          nodes.length
+        );
+      },
+      // インデックスを逆順にする
+      reverseIndex(index) {
+        return this.scatteredNodes.length - index;
+        // return 1,2,3,...
+      },
     },
-    // ノード数を考慮した角度を決める
-    radOfNode(nodeIndex, tierIndex, nodes) {
-      return (
-        (2 * Math.PI * nodeIndex + this.nodeParam.ROTATE_RADIAN * tierIndex) /
-        nodes.length
-      );
-    },
-    // インデックスを逆順にする
-    reverseIndex(index) {
-      return this.scatteredNodes.length - index;
-      // return 1,2,3,...
-    },
-  },
-};
+  };
 </script>
 
 <style>
-/* 円のスタイル設定 */
-circle {
-  fill: #67d5b5;
-  transition: all 0.4s cubic-bezier(0.96, 0.04, 0.04, 0.96);
-  stroke: #111010;
-  stroke-width: 0px;
-}
+  /* 円のスタイル設定 */
+  circle {
+    fill: #67d5b5;
+    transition: all 0.4s cubic-bezier(0.96, 0.04, 0.04, 0.96);
+    stroke: #111010;
+    stroke-width: 0px;
+  }
 
-.randomTags {
-  fill: #fce38a;
-}
+  .randomTags {
+    fill: #fce38a;
+  }
 </style>

--- a/pages/drafts/new.vue
+++ b/pages/drafts/new.vue
@@ -112,7 +112,7 @@
             article.tags.push(existingTag.id);
             // tagのvolumeを増やす
             console.debug("tag pushed :", article.tags)
-            this.$incrementArticlesCount(existingTag.id);
+            this.$incrementArticlesCount(existingTag.id, 1);
           }
         };
 

--- a/pages/landfill/index.vue
+++ b/pages/landfill/index.vue
@@ -1,0 +1,56 @@
+<template>
+  <div>
+    <div>いらない沼は埋め立てる</div>
+    <section class="hero">
+      <div class="hero-body">
+        <div class="container">
+          <h1 class="title">
+            沼の埋め立て地
+          </h1>
+        </div>
+      </div>
+    </section>
+    <input v-model="targetNodeId" class="input" placeholder="削除するタグのID" />
+    <button type="button" class="button is-success" @click="deleteTag">
+      タグと記事をまるごと削除する
+    </button>
+    <input v-model="articleId" class="input" placeholder="削除する記事のID" />
+    <button type="button" class="button is-success" @click="deleteArticle">
+      記事を削除する
+    </button>
+  </div>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        targetNodeId: "",
+        articleId: "",
+      };
+    },
+    methods: {
+      // 管理画面的なやつ
+      // (余力があったら)
+      // - タグの一覧を取ってくる
+      // - タグを一覧表示する
+      deleteArticle: async function () {
+        await this.$deleteArticle(this.articleId);
+        this.articleId = "";
+      },
+      deleteTag: async function () {
+        // ↓テスト用
+        // 1DXHJ3HRQORTg9oMg3Pz: 飲酒
+
+        // TODO: relativeサブコレクションのtags配列に含まれている該当タグを削除
+        // - 各タグのrelative内をidで検索して、参照を取得する
+        // TODO: タグ自体を削除
+        await this.$deleteTag(this.targetNodeId);
+        this.targetNodeId = "";
+      },
+    }
+  }
+
+</script>
+
+<style></style>

--- a/pages/landfill/index.vue
+++ b/pages/landfill/index.vue
@@ -39,12 +39,6 @@
         this.articleId = "";
       },
       deleteTag: async function () {
-        // ↓テスト用
-        // 1DXHJ3HRQORTg9oMg3Pz: 飲酒
-
-        // TODO: relativeサブコレクションのtags配列に含まれている該当タグを削除
-        // - 各タグのrelative内をidで検索して、参照を取得する
-        // TODO: タグ自体を削除
         await this.$deleteTag(this.targetNodeId);
         this.targetNodeId = "";
       },

--- a/plugins/firebaseUtils.js
+++ b/plugins/firebaseUtils.js
@@ -281,7 +281,97 @@ Vue.prototype.$addTagSuggestions = async function addTagSuggestions(
     })
     .catch((e) => {
       console.error(e);
+    })
+};
+
+// 記事を削除する
+Vue.prototype.$deleteArticle = async function deleteArticle(articleId) {
+  db.collection("articles")
+    .doc(articleId)
+    .delete()
+    .then(() => {
+      console.debug(`Article has been successfully deleted!: ${articleId}`);
+    }).catch((error) => {
+      console.error(`Error delete article: ${error}`);
+    })
+};
+
+// 全ての記事から該当タグを除外する
+// 該当タグしかついていなかったらその記事を削除
+Vue.prototype.$deleteTagWithArticle = async function deleteTagWithArticle(targetNodeId) {
+  await db
+    .collection("articles")
+    .where("tags", "array-contains", targetNodeId)
+    .get()
+    .then((queryResults) => {
+      queryResults.forEach((doc) => {
+        let article = doc.data();
+        console.debug(`Delete article (deleteTagWithArticle() in firebaseUtils.js): ${JSON.stringify(article)}`);
+        if (article.tags.length == 1) {
+          // 該当タグしかついていなかったら、記事自体を削除する
+          doc.ref.delete();
+        } else {
+          // 該当タグだけ削除する
+          doc.update({
+            tags: firebase.firestore.FieldValue.arrayRemove(targetNodeId)
+          })
+        }
+      });
+    })
+    .catch((error) => {
+      console.log(`Error : ${error}`);
     });
+};
+
+// 全てのタグのrelativeコレクションのtags配列からtargetNodeIdを削除する
+Vue.prototype.$deleteTagInRelative = async function deleteTagInRelative(targetNodeId) {
+  await db
+    .collectionGroup("relative")
+    .where("id", "==", targetNodeId)
+    .get()
+    .then((queryResults) => {
+      queryResults.forEach((doc) => {
+        doc.ref.delete();
+      })
+      console.debug(`tag in relative has been successfully deleted!: ${targetNodeId}`);
+    }).catch((error) => {
+      console.error(`Error delete article: ${error}`);
+    })
+};
+
+// タグの推薦リストから該当タグを削除する
+Vue.prototype.$removeTagFromSuggestions = async function removeTagFromSuggestions(targetNodeId) {
+  const tag = await Vue.prototype.$getTag(targetNodeId);
+  await db
+    .collection("tagSuggestions")
+    .doc("suggestions")
+    .update({
+      tagSuggestions: firebase.firestore.FieldValue.arrayRemove(tag.name)
+    })
+    .then(() => {
+      console.debug(`TagSuggestion has been successfully deleted!: ${tag.name}`);
+    }).catch((error) => {
+      console.error(`Error delete TagSuggestion: ${error}`);
+    })
+};
+
+// タグを削除する
+Vue.prototype.$deleteTag = async function deleteTag(targetNodeId) {
+  // タグの推薦リストから該当タグを削除する
+  await Vue.prototype.$removeTagFromSuggestions(targetNodeId);
+  // 全記事から該当タグを除外する
+  await Vue.prototype.$deleteTagWithArticle(targetNodeId);
+  // relativeに該当タグが含まれていたら、それを削除
+  await Vue.prototype.$deleteTagInRelative(targetNodeId);
+  // 該当タグ自身を削除
+  db.collection("tags")
+    .doc(targetNodeId)
+    .delete()
+    .then(() => {
+      console.debug(`Tag has been successfully deleted!: ${targetNodeId}`);
+    }).catch((error) => {
+      console.error(`Error delete tag: ${error}`);
+    })
 };
 
 export default (context) => {
@@ -296,6 +386,8 @@ export default (context) => {
   context.$incrementArticlesCount = Vue.prototype.$incrementArticlesCount;
   context.$getSuggestions = Vue.prototype.$getSuggestions;
   context.$addTagSuggestions = Vue.prototype.$addTagSuggestions;
+  context.$deleteArticle = Vue.prototype.$deleteArticle;
+  context.$deleteTag = Vue.prototype.$deleteTag;
 };
 // 現在時刻を取得する
 Vue.prototype.$getFirebaseTimestamp = async function getFirebaseTimestamp() {


### PR DESCRIPTION
## 変更内容
<!-- PRの概要を書いてね -->
<!-- フロント関連の場合はスクリーンショットとかを貼るとレビューが楽だよ -->
### タグ・記事を削除する画面を作成した！
削除したいタグまたは記事のIDを検索して、ボタン1つで削除できます。
他のページからは遷移できないようになっているので、URLを直接叩いてください！

### volumeをarticlesCountをもとに計算するようにした！

![image](https://user-images.githubusercontent.com/47709871/104092985-ce1fe400-52ca-11eb-97f7-0f82bed40b4a.png)

## Issue
<!-- 対応するissue番号を書いてね -->
close #89
