### PR TITLE
ADD: タグの自動挿入機能

### DIFF
--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -32,7 +32,14 @@
             "
             >趣味を探す</a
           >
-          <a class="navbar-item" @click="$router.push(`/drafts/new`)"
+          <a
+            class="navbar-item"
+            @click="
+              $router.push({
+                path: `/drafts/new`,
+                query: { tagId: $route.params.nodeId },
+              })
+            "
             >趣味を書く</a
           >
         </div>

--- a/pages/drafts/new.vue
+++ b/pages/drafts/new.vue
@@ -89,9 +89,18 @@
 import "mavon-editor/dist/css/index.css";
 
 export default {
-  async asyncData({ $getSuggestions }) {
+  async asyncData({ query, $getTag, $getSuggestions }) {
+    let recommendedTagName = "";
+    if (typeof query.tagId !== "undefined") {
+      // クエリパラメータにtagIdが渡されていたら、そのタグを推薦
+      const recommendedTag = await $getTag(query.tagId);
+      recommendedTagName = recommendedTag.name;
+    }
     let data = await $getSuggestions();
-    return { tagSuggestions: data.tagSuggestions };
+    return {
+      recommendedTagName: recommendedTagName,
+      tagSuggestions: data.tagSuggestions,
+    };
   },
   data() {
     return {
@@ -122,6 +131,11 @@ export default {
         help: true,
       },
     };
+  },
+
+  created() {
+    // 直前に見ていた趣味のタグをプリセットする
+    this.searchTexts[0] = this.recommendedTagName;
   },
 
   methods: {


### PR DESCRIPTION
## 変更内容
<!-- PRの概要を書いてね -->
<!-- フロント関連の場合はスクリーンショットとかを貼るとレビューが楽だよ -->
「記事を書く」を押したときにタグIDをクエリパラメータで渡す実装にした！
Home、グラフ画面、記事一覧画面、記事詳細画面のどの画面から遷移しても正常に動作するはず！

（"空"のグラフを見ていて「記事を書く」を押した場合）
![image](https://user-images.githubusercontent.com/47709871/104692618-9cd06980-574b-11eb-9daa-a8221c890d22.png)
↓↓↓↓↓↓↓
![image](https://user-images.githubusercontent.com/47709871/104692654-ace84900-574b-11eb-957e-4f646b63b359.png)

## Issue
<!-- 対応するissue番号を書いてね -->
close #42
close #61
